### PR TITLE
add: JamfPro.initialize_access_token!

### DIFF
--- a/generator/template/gem.mustache
+++ b/generator/template/gem.mustache
@@ -60,5 +60,16 @@ module {{moduleName}}
         Configuration.default
       end
     end
+
+    def initialize_access_token!
+      client   = ApiAuthenticationApi.new
+      response = client.v1_auth_token_post
+
+      self.configure do |config|
+        config.default.access_token = response.token
+        config.username = nil
+        config.password = nil
+      end
+    end
   end
 end

--- a/lib/ruby-jamf-pro-api-client.rb
+++ b/lib/ruby-jamf-pro-api-client.rb
@@ -590,5 +590,16 @@ module JamfPro
         Configuration.default
       end
     end
+
+    def initialize_access_token!
+      client   = ApiAuthenticationApi.new
+      response = client.v1_auth_token_post
+
+      self.configure do |config|
+        config.default.access_token = response.token
+        config.username = nil
+        config.password = nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Initializing access tokens is a bit of a tedious procedure 😵‍💫 

```ruby
JamfPro.configure do |config|
  config.username = 'user'
  config.password = 'password'
end

client   = ApiAuthenticationApi.new
response = client.v1_auth_token_post

JamfPro.configure do |config|
  config.access_token = response.token
end

# let's write codes ...
client.v1_jamf_pro_version_get
```

This PR adds  `JamfPro.initialize_access_token` to solve. 